### PR TITLE
Fix round counting and result displays for tap test

### DIFF
--- a/src/components/game/GameResult.tsx
+++ b/src/components/game/GameResult.tsx
@@ -96,12 +96,23 @@ export const GameResult: React.FC<GameResultProps> = ({
           statistics.validAttempts > 0 ? COLORS.INFO : COLORS.TEXT_SECONDARY
         )}
         
-        {renderStatCard(
-          '정확도',
-          `${Math.round((statistics.validAttempts / statistics.totalAttempts) * 100)}%`,
-          `${statistics.validAttempts}/${statistics.totalAttempts}`,
-          statistics.validAttempts === statistics.totalAttempts ? COLORS.SUCCESS : COLORS.WARNING
-        )}
+        {(() => {
+          const accuracy =
+            statistics.totalAttempts > 0
+              ? Math.round(
+                  (statistics.validAttempts / statistics.totalAttempts) * 100
+                )
+              : 0;
+          return renderStatCard(
+            '정확도',
+            `${accuracy}%`,
+            `${statistics.validAttempts}/${statistics.totalAttempts}`,
+            statistics.totalAttempts > 0 &&
+            statistics.validAttempts === statistics.totalAttempts
+              ? COLORS.SUCCESS
+              : COLORS.WARNING
+          );
+        })()}
         
         {statistics.worstTime > 0 && statistics.validAttempts > 1 && renderStatCard(
           '최저 기록',

--- a/src/screens/game/ResultScreen.tsx
+++ b/src/screens/game/ResultScreen.tsx
@@ -74,10 +74,23 @@ export const ResultScreen: React.FC<ResultScreenProps> = ({ navigation, route })
         gameSession.statistics.averageTime,
         gameSession.statistics.validAttempts > 0
       );
-      const shareText = `QuickReflex 순발력 테스트 결과!\n\n` +
-        `평균 반응시간: ${GameLogic.formatTime(gameSession.statistics.averageTime)}\n` +
-        `최고 반응시간: ${GameLogic.formatTime(gameSession.statistics.bestTime)}\n` +
-        `정확도: ${Math.round((gameSession.statistics.validAttempts / gameSession.statistics.totalAttempts) * 100)}%\n\n` +
+      const accuracy =
+        gameSession.statistics.totalAttempts > 0
+          ? Math.round(
+              (gameSession.statistics.validAttempts /
+                gameSession.statistics.totalAttempts) *
+                100
+            )
+          : 0;
+      const shareText =
+        `QuickReflex 순발력 테스트 결과!\n\n` +
+        `평균 반응시간: ${GameLogic.formatTime(
+          gameSession.statistics.averageTime
+        )}\n` +
+        `최고 반응시간: ${GameLogic.formatTime(
+          gameSession.statistics.bestTime
+        )}\n` +
+        `정확도: ${accuracy}%\n\n` +
         `${performance.message} 🎉\n\n` +
         `당신도 도전해보세요! #QuickReflex #순발력테스트`;
 

--- a/src/utils/statistics.ts
+++ b/src/utils/statistics.ts
@@ -21,6 +21,10 @@ export class StatisticsUtils {
     const firstAverage = recentSessions[0].statistics.averageTime;
     const lastAverage = recentSessions[recentSessions.length - 1].statistics.averageTime;
 
+    if (firstAverage === 0) {
+      return { trend: 'STABLE', percentage: 0 };
+    }
+
     const improvementPercentage = ((firstAverage - lastAverage) / firstAverage) * 100;
 
     if (Math.abs(improvementPercentage) < 5) {


### PR DESCRIPTION
## Summary
- ensure tap test runs exactly five rounds and continue after failed attempts
- show red completion screen when all attempts fail and improve header/quick stats alignment
- prevent NaN/Infinity in accuracy and comparison metrics

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68989266d9a48325b6622671dc92e60f